### PR TITLE
Migrate fpdf to tinywasm/fmt and standardize errors

### DIFF
--- a/docs/TINYGO_PORT.md
+++ b/docs/TINYGO_PORT.md
@@ -23,11 +23,11 @@ Fpdf currently imports standard library packages that significantly increase bin
 - [x] `font_afm.go` (6 instances)
 - [x] `utf8fontfile.go` (2 instances)
 - [x] `fonts.go` (2 instances)
-- [ ] `svgbasic.go` 
-- [ ] `htmlbasic.go` 
-- [ ] `grid.go` 
-- [ ] `embedded.go` 
-- [ ] `makefont.go` 
+- [x] `svgbasic.go`
+- [x] `htmlbasic.go`
+- [x] `grid.go`
+- [x] `embedded.go`
+- [x] `makefont.go`
 - [ ] `gofpdi/helper.go` 
 - [ ] `gofpdi/importer.go` 
 - [ ] `gofpdi/writer.go` 
@@ -191,9 +191,9 @@ str := Convert(3.14159).Round(2).String()
 ## File-by-File Migration Checklist
 
 ### Core Files (Priority 1)
-- [ ] `util.go` - Remove `fmt.Sprintf`
-- [ ] `document.go` - Replace 5x `fmt.Errorf`, 1x `fmt.Sprintf`  
-- [ ] `fonts.go` - Replace 2x `fmt.Errorf`, 1x `fmt.Printf`, 1x `fmt.Sprintf`
+- [x] `util.go` - Remove `fmt.Sprintf`
+- [x] `document.go` - Replace 5x `fmt.Errorf`, 1x `fmt.Sprintf`
+- [x] `fonts.go` - Replace 2x `fmt.Errorf`, 1x `fmt.Printf`, 1x `fmt.Sprintf`
 - [ ] `drawing.go` - Replace 3x `fmt.Errorf`
 - [ ] `spotcolor.go` - Replace 2x `fmt.Errorf`
 

--- a/fpdf/embedded.go
+++ b/fpdf/embedded.go
@@ -5,7 +5,8 @@ package fpdf
 import (
 	"embed"
 	"io"
-	"strings"
+
+	. "github.com/tinywasm/fmt"
 )
 
 //go:embed font_embed/*.json font_embed/*.map
@@ -13,12 +14,12 @@ var embFS embed.FS
 
 func (f *Fpdf) coreFontReader(familyStr, styleStr string) (r io.ReadCloser) {
 	key := familyStr + styleStr
-	key = strings.ToLower(key)
+	key = Convert(key).Low().String()
 	emb, err := embFS.Open("font_embed/" + key + ".json")
 	if err == nil {
 		r = emb
-	} else {
-		f.SetErrorf("could not locate \"%s\" among embedded core font definition files", key)
+	} else if f.err == nil {
+		f.err = Err("core font definition", key, "missing")
 	}
 	return
 }

--- a/fpdf/grid.go
+++ b/fpdf/grid.go
@@ -2,7 +2,8 @@ package fpdf
 
 import (
 	"math"
-	"strconv"
+
+	. "github.com/tinywasm/fmt"
 )
 
 // RGBType holds fields for red, green and blue color components (0..255)
@@ -57,7 +58,7 @@ type TickFormatFncType func(val float64, precision int) string
 
 // defaultFormatter returns the string form of val with precision decimal places.
 func defaultFormatter(val float64, precision int) string {
-	return strconv.FormatFloat(val, 'f', precision, 64)
+	return Convert(val).Round(precision).String()
 }
 
 // GridType assists with the generation of graphs. It allows the application to

--- a/fpdf/htmlbasic.go
+++ b/fpdf/htmlbasic.go
@@ -2,7 +2,8 @@ package fpdf
 
 import (
 	"regexp"
-	"strings"
+
+	. "github.com/tinywasm/fmt"
 )
 
 // HTMLBasicSegmentType defines a segment of literal text in which the current
@@ -19,8 +20,7 @@ type HTMLBasicSegmentType struct {
 func HTMLBasicTokenize(htmlStr string) (list []HTMLBasicSegmentType) {
 	// This routine is adapted from http://www.fpdf.org/
 	list = make([]HTMLBasicSegmentType, 0, 16)
-	htmlStr = strings.Replace(htmlStr, "\n", " ", -1)
-	htmlStr = strings.Replace(htmlStr, "\r", "", -1)
+	htmlStr = Convert(htmlStr).Replace("\n", " ").Replace("\r", "").String()
 	tagRe, _ := regexp.Compile(`(?U)<.*>`)
 	attrRe, _ := regexp.Compile(`([^=]+)=["']?([^"']+)`)
 	capList := tagRe.FindAllStringIndex(htmlStr, -1)
@@ -37,22 +37,22 @@ func HTMLBasicTokenize(htmlStr string) (list []HTMLBasicSegmentType) {
 			}
 			if htmlStr[cap[0]+1] == '/' {
 				seg.Cat = 'C'
-				seg.Str = strings.ToLower(htmlStr[cap[0]+2 : cap[1]-1])
+				seg.Str = Convert(htmlStr[cap[0]+2 : cap[1]-1]).Low().String()
 				seg.Attr = nil
 				list = append(list, seg)
 			} else {
 				// Extract attributes
-				parts = strings.Split(htmlStr[cap[0]+1:cap[1]-1], " ")
+				parts = Convert(htmlStr[cap[0]+1 : cap[1]-1]).Split(" ")
 				if len(parts) > 0 {
 					for j, part := range parts {
 						if j == 0 {
 							seg.Cat = 'O'
-							seg.Str = strings.ToLower(parts[0])
+							seg.Str = Convert(parts[0]).Low().String()
 							seg.Attr = make(map[string]string)
 						} else {
 							attrList := attrRe.FindAllStringSubmatch(part, -1)
 							for _, attr := range attrList {
-								seg.Attr[strings.ToLower(attr[1])] = attr[2]
+								seg.Attr[Convert(attr[1]).Low().String()] = attr[2]
 							}
 						}
 					}

--- a/fpdf/makefont/makefont.go
+++ b/fpdf/makefont/makefont.go
@@ -2,27 +2,27 @@ package main
 
 import (
 	"flag"
-	"fmt"
 	"os"
 
+	. "github.com/tinywasm/fmt"
 	"github.com/tinywasm/pdf/fpdf"
 )
 
 func errPrintf(fmtStr string, args ...any) {
-	fmt.Fprintf(os.Stderr, fmtStr, args...)
+	os.Stderr.WriteString(Sprintf(fmtStr, args...))
 }
 
 func showHelp() {
 	errPrintf("Usage: %s [options] font_file [font_file...]\n", os.Args[0])
 	flag.PrintDefaults()
-	fmt.Fprintln(os.Stderr, "\n"+
-		"font_file is the name of the TrueType file (extension .ttf), OpenType file\n"+
-		"(extension .otf) or binary Type1 file (extension .pfb) from which to\n"+
-		"generate a definition file. If an OpenType file is specified, it must be one\n"+
-		"that is based on TrueType outlines, not PostScript outlines; this cannot be\n"+
-		"determined from the file extension alone. If a Type1 file is specified, a\n"+
-		"metric file with the same pathname except with the extension .afm must be\n"+
-		"present.")
+	os.Stderr.WriteString("\n" +
+		"font_file is the name of the TrueType file (extension .ttf), OpenType file\n" +
+		"(extension .otf) or binary Type1 file (extension .pfb) from which to\n" +
+		"generate a definition file. If an OpenType file is specified, it must be one\n" +
+		"that is based on TrueType outlines, not PostScript outlines; this cannot be\n" +
+		"determined from the file extension alone. If a Type1 file is specified, a\n" +
+		"metric file with the same pathname except with the extension .afm must be\n" +
+		"present.\n")
 	errPrintf("\nExample: %s --embed --enc=../font/cp1252.map --dst=../font calligra.ttf /opt/font/symbol.pfb\n", os.Args[0])
 }
 


### PR DESCRIPTION
This PR continues the TinyGo port migration for the `fpdf` library. It removes dependencies on `fmt`, `strings`, and `strconv` from several key files (`svgbasic.go`, `htmlbasic.go`, `grid.go`, `embedded.go`, `makefont.go`, `font.go`) by leveraging `github.com/tinywasm/fmt`.

Key changes:
- Replaced `fmt.Errorf` and `fmt.Sprintf` with `Err` and `Sprintf` from `tinywasm/fmt`.
- Enforced strict "Noun + Adjective" error message pattern (e.g., "Format Invalid").
- Replaced `strings` and `strconv` functions with `Convert` chainable API and standalone helpers like `HasSuffix`.
- Refactored `fpdf/font.go` `loadMap` function to parse font encoding maps manually, replacing `fmt.Sscanf`.
- Updated `docs/TINYGO_PORT.md` to reflect the completed migration of these files.

---
*PR created automatically by Jules for task [11790509347372969002](https://jules.google.com/task/11790509347372969002) started by @cdvelop*